### PR TITLE
Fix zip filename and timestamp after global restore

### DIFF
--- a/src/model/BackupsModel.php
+++ b/src/model/BackupsModel.php
@@ -35,7 +35,7 @@ class BackupsModel extends PageModel
 
             (is_bool($zipData->locateName('data/pages.json')) === TRUE) ? $check = FALSE : $check = TRUE; 
             if ($check) {
-                $backupPages = json_decode(file_get_contents("zip://".$file_path."#data/pages.json"),true);
+                $backupPages = json_decode(file_get_contents("zip://".realpath($file_path)."#data/pages.json"),true);
                 foreach ($backupPages as $pages) {
                     (is_bool($zipData->locateName($pages['pages']['phppath'])) === TRUE || is_bool($zipData->locateName($pages['pages']['jsonpath'])) === TRUE) ? $check = FALSE : $check = TRUE; 
                 }

--- a/src/model/BackupsModel.php
+++ b/src/model/BackupsModel.php
@@ -132,7 +132,7 @@ class BackupsModel extends PageModel
         if(file_exists('data/accesslog.json'))array_push($assets, 'data/accesslog.json');
         
         $this->doc = new DocBuilder;
-        $filename = 'data/DocPHT_Backup_' . $this->doc->datetimeNow() . '_'.uniqid().'.zip';
+        $filename = 'data/DocPHT_Backup_' . str_replace(":", "-", $this->doc->datetimeNow()) . '_'.uniqid().'.zip';
         
         if (is_array($pages) && count($pages) > 0) {
             foreach($pages as $page) {

--- a/src/model/VersionModel.php
+++ b/src/model/VersionModel.php
@@ -105,7 +105,7 @@ class VersionModel extends PageModel
         $this->doc = new DocBuilder;
         $path = $this->getPhpPath($id);
         if (isset($id)) {
-        	$zippedVersionPath = 'data/' . $this->getSlug($id) . '_' . $this->doc->datetimeNow() . '.zip';
+        	$zippedVersionPath = 'data/' . $this->getSlug($id) . '_' . str_replace(":", "-", $this->doc->datetimeNow()) . '.zip';
         } else {
             die;
         }

--- a/src/model/VersionModel.php
+++ b/src/model/VersionModel.php
@@ -66,7 +66,11 @@ class VersionModel extends PageModel
         $versionList = array();
         foreach (glob($zippedVersionPath . $filePattern) as $file) {
             $addFile = $this->checkVersion($file, $id);
-            if($addFile) array_push($versionList, ['path' => $file, 'date' => filemtime($file)]);
+
+            $filenameChunks = explode('_', $file);
+            $versionTimestamp = substr(end($filenameChunks),0,-4);
+
+            if($addFile) array_push($versionList, ['path' => $file, 'date' => $versionTimestamp]);
         }
         
         return $this->sortVersions($versionList);
@@ -105,7 +109,7 @@ class VersionModel extends PageModel
         $this->doc = new DocBuilder;
         $path = $this->getPhpPath($id);
         if (isset($id)) {
-        	$zippedVersionPath = 'data/' . $this->getSlug($id) . '_' . str_replace(":", "-", $this->doc->datetimeNow()) . '.zip';
+        	$zippedVersionPath = 'data/' . $this->getSlug($id) . '_' . str_replace(":", "-", $this->doc->datetimeNow()) . '_' . time() . '.zip';
         } else {
             die;
         }

--- a/temp/install/config.php
+++ b/temp/install/config.php
@@ -78,7 +78,7 @@ $date = [
     'd-m-Y H:i' => date('d-m-Y H:i'),
     'Y-m-d H:i' => date('Y-m-d H:i')
 ];
-$form->addRadioList('dataformat', 'Data format', $date)->setRequired('Required');
+$form->addRadioList('dataformat', 'Date format', $date)->setRequired('Required');
 
 $actualPath = (isSecure() ? "https" : "http") . "://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
 if (substr($actualPath, -1) != '/') {


### PR DESCRIPTION
Hi,

Here are some changes for windows users to fix bad zip filename (the colons is a restricted characters) and to fix access to internal zip files (when using the `zip://` protocol) during backup processing.

I also add a change to improve the situation after a backup restore. It avoid page versions to be all timestamped with the same date & time value (the one of the backup creation time)