### PR TITLE
Allow setting sender's email in config

### DIFF
--- a/src/forms/AddUserForm.php
+++ b/src/forms/AddUserForm.php
@@ -88,7 +88,7 @@ class AddUserForm extends MakeupForm
                     ]; 
 
                     $mail = new Message;
-                    $mail->setFrom('no-reply@'.DOMAIN_NAME.'')
+                    $mail->setFrom(SMTPFROM)
                         ->addTo($values['username'])
                         ->setSubject('New account '.DOMAIN_NAME.' ')
                         ->setHtmlBody($latte->renderToString('src/views/email/new_account.latte', $params));

--- a/src/forms/LostPasswordForm.php
+++ b/src/forms/LostPasswordForm.php
@@ -55,7 +55,7 @@ class LostPasswordForm extends MakeupForm
                     ]; 
 
                     $mail = new Message;
-                    $mail->setFrom('no-reply@'.DOMAIN_NAME.'')
+                    $mail->setFrom(SMTPFROM)
                         ->addTo($values['email'])
                         ->setSubject('Reset password '.DOMAIN_NAME.' ')
                         ->setHtmlBody($latte->renderToString('src/views/email/recovery_password.latte', $params));

--- a/temp/install/config.php
+++ b/temp/install/config.php
@@ -143,6 +143,7 @@ if ($form->isSuccess()) {
             .'define("SMTPHOST","");'."\n"
             .'define("SMTPPORT","");'."\n"
             .'define("SMTPENCRYPT","");'."\n"
+            .'define("SMTPFROM","no-reply@".DOMAIN_NAME);'."\n"
             .'define("SMTPUSERNAME","");'."\n"
             .'define("SMTPPASSWORD","");'."\n"
         ;


### PR DESCRIPTION
Being able to set the sender's address is cruical when using SMTP as servers decline emails not coming from the user logged in. Example: Using gmail for outgoing mails.